### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/.roo/rules-code/06-github-workflow.md
+++ b/.roo/rules-code/06-github-workflow.md
@@ -29,7 +29,7 @@
 
 - You should not be using the autogen package, use autogen-core
 - Do not use autogen-agentchat, only autogen-core
-- Any modules that are using pyautogen should be corrected/rewritten to use autogen-core
+- Any modules that are using ag2 should be corrected/rewritten to use autogen-core
 - For the implementation, you will need to use Azure credentials to access the Azure OpenAI API using Tenant: 3cd87a41-1f61-4aef-a212-cefdecd9a2d1
 - You will need to do a commit after each step of the implementation
 - If a step of the implementation is not clear, please ask for clarification


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
